### PR TITLE
Fix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Requirements:
 To clone and run a development server on your machine (that autoupdates when you modify files):
 
 ```
-git clone https://github.com/meower-media-co/Meower-Svelte
-cd Meower-Svelte
+git clone https://github.com/meower-media/client
+cd client
 npm install
 npm run dev
 ```

--- a/src/lib/ProfileView.svelte
+++ b/src/lib/ProfileView.svelte
@@ -276,7 +276,7 @@
 			<pre><code>{e}</code></pre>
 			Try again. If this issue persists,
 			<a
-				href="https://github.com/Meower-Media-Co/Meower-Svelte/issues/new"
+				href="https://github.com/meower-media/client/issues/new"
 				>create an issue on Meower Svelte's issue tracker</a
 			> with the error code shown above.
 		</Container>

--- a/src/lib/modals/StartupError.svelte
+++ b/src/lib/modals/StartupError.svelte
@@ -13,7 +13,7 @@
 	<div slot="default">
 		<p>{"We encountered an error while starting Meower, Here's some info that may help: "+error}</p>
         <p>Try reloading, and if this happens again, <a
-				href="https://github.com/Meower-Media-Co/Meower-Svelte/issues/new"
+				href="https://github.com/meower-media/client/issues/new"
 				>create an issue on Meower Svelte's issue tracker</a
 			> with the info shown above.
         </p>

--- a/src/pages/about.svelte
+++ b/src/pages/about.svelte
@@ -40,7 +40,7 @@
 	<a href="https://meower.org" target="_blank" rel="noreferrer">Learn more</a>
 	|
 	<a
-		href="https://github.com/meower-media-co"
+		href="https://github.com/meower-media"
 		target="_blank"
 		rel="noreferrer">Source code</a
 	>


### PR DESCRIPTION
There are many links that refer back to the old Meower Media GitHub org, this commit fixes them to go to the new one and the correct repo.